### PR TITLE
Add basic Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Telegram Bot
+
+Este repositório inclui um exemplo simples de bot para Telegram utilizando a biblioteca [pytelegrambotapi](https://pypi.org/project/pytelegrambotapi/).
+
+## Como utilizar
+
+1. Instale as dependências:
+   ```bash
+   pip install pytelegrambotapi
+   ```
+
+2. Defina a variável de ambiente `TELEGRAM_BOT_TOKEN` com o token do seu bot ou edite o arquivo `telegram_bot.py` substituindo `PUT_YOUR_TOKEN_HERE` pelo seu token.
+
+3. Execute o bot:
+   ```bash
+   python telegram_bot.py
+   ```
+
+O bot responde ao comando `/start` ou `/help` com uma mensagem de boas-vindas e ecoa todas as outras mensagens recebidas.

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,18 @@
+import os
+import telebot
+
+TOKEN = os.environ.get('TELEGRAM_BOT_TOKEN', 'PUT_YOUR_TOKEN_HERE')
+
+bot = telebot.TeleBot(TOKEN)
+
+@bot.message_handler(commands=['start', 'help'])
+def send_welcome(message):
+    bot.reply_to(message, 'Olá! Eu sou um chatbot do Telegram.')
+
+@bot.message_handler(func=lambda m: True)
+def echo_message(message):
+    bot.reply_to(message, message.text)
+
+if __name__ == '__main__':
+    print('Bot rodando...')
+    bot.infinity_polling()


### PR DESCRIPTION
## Summary
- add simple example using pytelegrambotapi
- document how to run the bot

## Testing
- `python -m pip install pytelegrambotapi`
- `python telegram_bot.py --help` *(fails: Token must contain a colon)*

------
https://chatgpt.com/codex/tasks/task_e_684775340f18832f8ba0cdc70002502c